### PR TITLE
measurement type convertion

### DIFF
--- a/app/views/users/Customer/v_c_addshirt.php
+++ b/app/views/users/Customer/v_c_addshirt.php
@@ -12,9 +12,9 @@
               <input type="hidden" name="is_create" value="<?php echo empty($data['shirt']) ? '1' : '0'; ?>">
               <label for="measure">Measurement type</label>
                 <div class="radiobtn">
-                    <input type="radio" id="cm" name="measurement_unit" value="1" <?php echo isset($data['shirt']->measure) && $data['shirt']->measure == '1' ? 'checked' : ''; ?>>
+                    <input type="radio" id="cm" name="measurement_unit" value="cm" <?php echo isset($data['shirt']->measure) && $data['shirt']->measure == 'cm' ? 'checked' : ''; ?>>
                     <label for="cm">cm</label>
-                    <input type="radio" id="inch" name="measurement_unit" value="2" <?php echo isset($data['shirt']->measure) && $data['shirt']->measure == '2' ? 'checked' : ''; ?>>
+                    <input type="radio" id="inch" name="measurement_unit" value="inch" <?php echo isset($data['shirt']->measure) && $data['shirt']->measure == 'inch' ? 'checked' : ''; ?>>
                     <label for="inch">inch</label><br><br>
                 </div>
               <label for="Collar size">Collar size</label>
@@ -96,33 +96,102 @@
 </body>
 </html>
 <script>
-    const form = document.querySelector('.change-form');
-    const inputs = form.querySelectorAll('input[type="text"], input[type="radio"]'); // Select all relevant inputs
-    const saveButton = form.querySelector('.btn-save');
+const form = document.querySelector('.change-form');
+const inputs = form.querySelectorAll('input[type="text"]');
+const cmRadio = document.getElementById('cm');
+const inchRadio = document.getElementById('inch');
+const saveButton = form.querySelector('.btn-save');
 
-    let originalValues = {}; // Store original values
+// Conversion constants
+const CM_TO_INCH = 0.393701;
+const INCH_TO_CM = 2.54;
 
+// Store original values and their units
+let measurementStore = {};
+
+// Initialize measurement store based on database value and unit
+window.addEventListener('load', function() {
     inputs.forEach(input => {
-        originalValues[input.id] = input.value; // Store initial values
-        input.addEventListener('input', enableSaveButton);
-        input.addEventListener('change', enableSaveButton); // For radio buttons
+        const measurementId = input.id.replace(' ', ''); // Adjust if your database column names differ
+        const databaseValue = parseFloat(input.value);
+        const databaseUnit = cmRadio.checked ? 'cm' : (inchRadio.checked ? 'inch' : 'cm'); // Default to cm if neither is checked initially
+
+        if (!isNaN(databaseValue)) {
+            if (databaseUnit === 'cm') {
+                measurementStore[input.id] = {
+                    cm: databaseValue,
+                    inch: (databaseValue * CM_TO_INCH).toFixed(2)
+                };
+            } else if (databaseUnit === 'inch') {
+                measurementStore[input.id] = {
+                    cm: (databaseValue * INCH_TO_CM).toFixed(2),
+                    inch: databaseValue
+                };
+            } else {
+                // Handle unknown unit (shouldn't happen if radio buttons are correctly set)
+                measurementStore[input.id] = { cm: databaseValue, inch: (databaseValue * CM_TO_INCH).toFixed(2) }; // Default to cm
+            }
+        } else {
+            measurementStore[input.id] = { cm: '', inch: '' };
+        }
     });
+    toggleInputs(); // Initial display based on checked radio
+});
 
-    function enableSaveButton() {
-        let formChanged = false;
-        inputs.forEach(input => {
-          if (input.type === 'radio') {
-            if (input.checked !== (originalValues[input.id] === input.value)) {
-                formChanged = true;
-            }
-          } else if (input.value !== originalValues[input.id]) {
-                formChanged = true;
-            }
-        });
+// Show inputs based on selected unit
+function toggleInputs() {
+    inputs.forEach(input => {
+        const currentUnit = cmRadio.checked ? 'cm' : 'inch';
+        input.value = measurementStore[input.id][currentUnit] || ''; // Use empty string if value is undefined
+        input.style.display = measurementStore[input.id][currentUnit] !== undefined ? 'block' : 'none';
+    });
+}
 
-        saveButton.style.display = formChanged ? 'block' : 'none';
-    }
+// Handle unit change
+cmRadio.addEventListener('change', toggleInputs);
+inchRadio.addEventListener('change', toggleInputs);
+
+// Update both cm and inch values when input changes
+inputs.forEach(input => {
+    input.addEventListener('input', function() {
+        // Allow only numerical input
+        this.value = this.value.replace(/[^0-9.]/g, '');
+
+        if (this.value) {
+            const currentValue = parseFloat(this.value);
+            if (!isNaN(currentValue)) {
+                enableSaveButton();
+                if (cmRadio.checked) {
+                    measurementStore[this.id] = {
+                        cm: currentValue,
+                        inch: (currentValue * CM_TO_INCH).toFixed(2)
+                    };
+                } else {
+                    measurementStore[this.id] = {
+                        cm: (currentValue * INCH_TO_CM).toFixed(2),
+                        inch: currentValue
+                    };
+                }
+            }
+        } else {
+            measurementStore[this.id].cm = '';
+            measurementStore[this.id].inch = '';
+            enableSaveButton();
+        }
+    });
+});
+
+// Enable save button if form changes
+function enableSaveButton() {
+    let formChanged = false;
+    inputs.forEach(input => {
+        const originalValue = cmRadio.checked ?
+            (measurementStore[input.id] ? measurementStore[input.id].cm : '') :
+            (measurementStore[input.id] ? measurementStore[input.id].inch : '');
+        if (parseFloat(input.value) !== parseFloat(originalValue)) {
+            formChanged = true;
+        }
+    });
+    saveButton.style.display = formChanged ? 'block' : 'none';
+}
 </script>
-
-<?php require_once APPROOT . '/views/users/Customer/inc/footer.php'; ?>
-

--- a/public/css/customer/Customer_profilenew.css
+++ b/public/css/customer/Customer_profilenew.css
@@ -243,8 +243,7 @@
 
   .delete-btn{
     padding: 10px 20px;
-    background: var(--danger-dark-color);;
-    /* background-color: #007bff; */
+    background: var(--danger-dark-color);
     color: rgb(255, 255, 255);
     border: none;
     border-radius: 5px;


### PR DESCRIPTION
This pull request introduces improvements to the shirt measurement form, adds dynamic unit conversion functionality, and includes a minor CSS cleanup. The most significant changes involve updating the measurement unit handling to use descriptive values (`cm` and `inch`) and implementing JavaScript logic to dynamically toggle and convert measurement inputs based on the selected unit.

### Changes to measurement unit handling:

* Updated the `measurement_unit` radio button values in `app/views/users/Customer/v_c_addshirt.php` to use descriptive strings (`cm` and `inch`) instead of numeric values (`1` and `2`). This improves code clarity and maintainability.

### JavaScript enhancements for dynamic unit conversion:

* Introduced constants for unit conversion (`CM_TO_INCH` and `INCH_TO_CM`) and added logic to store and toggle measurement values between units (`cm` and `inch`) dynamically. This ensures accurate conversions and updates to the form inputs based on the selected unit.
* Added input validation to allow only numerical values and updated the save button logic to reflect changes in the measurement inputs.

### CSS cleanup:

* Removed an unnecessary duplicate semicolon in the `.delete-btn` style in `public/css/customer/Customer_profilenew.css`, improving code cleanliness.