### PR TITLE
Pass order ID from controller to model for order creation

### DIFF
--- a/app/controllers/Orders.php
+++ b/app/controllers/Orders.php
@@ -525,6 +525,7 @@ class Orders extends Controller
             $orderData['appointment_id'] = null;
         }
 
+        $orderData['order_id'] = $orderNumber;
         // Save to database
         $createdOrderId = $this->orderModel->createOrder($orderData);
 
@@ -571,7 +572,7 @@ class Orders extends Controller
             'design_id' => $_SESSION['order_details']['design']->design_id,
             'fabric_id' => $_SESSION['order_details']['fabric']->fabric_id,
             'color_id' => $_SESSION['order_details']['color']->color_id,
-            'quantity' => 1, // Default to 1 for now
+            'quantity' => 1,
             'base_price' => $_SESSION['order_details']['design']->base_price,
             'fabric_price' => $_SESSION['order_details']['fabric']->price_adjustment ?? 0,
             'customization_price' => $this->calculateCustomizationPrice(),

--- a/app/models/M_Orders.php
+++ b/app/models/M_Orders.php
@@ -318,9 +318,10 @@ class M_Orders
         try {
             $this->db->beginTransaction();
 
-            // Generate the order ID
-            $orderId = $this->generateOrderId();
 
+            // Use the order ID passed from the controller
+            $orderId = $orderData['order_id'];
+            
             // Insert the main order
             $this->db->query('INSERT INTO orders (
                 order_id, customer_id, tailor_id, total_amount, 


### PR DESCRIPTION
This pull request introduces changes to the order processing flow in the `Orders` controller and `M_Orders` model to ensure that the `order_id` is generated in the controller and passed to the model, instead of being generated within the model. Additionally, a minor cleanup was performed in the `prepareOrderItems` method.

### Changes to order processing flow:

* `app/controllers/Orders.php`:
  - Added assignment of `order_id` to the `$orderData` array in the `processPayment` method to ensure the ID is generated and passed to the model.

* `app/models/M_Orders.php`:
  - Modified the `createOrder` method to use the `order_id` passed from the controller instead of generating it within the model. This aligns the model's behavior with the controller's responsibility for ID generation.

### Minor cleanup:

* `app/controllers/Orders.php`:
  - Removed an unnecessary comment in the `prepareOrderItems` method, simplifying the code without altering functionality.