### PR TITLE
feat: Update order image display logic to show custom images or defau…

### DIFF
--- a/app/views/users/Customer/v_c_orders.php
+++ b/app/views/users/Customer/v_c_orders.php
@@ -11,7 +11,11 @@
             <div class="order">
             <div class="order-image">
                 <div class="image-wrapper">
-                    <img src="<?php echo URLROOT; ?>/public/img/designs/shirt1.jpg" alt="Black Shirt">
+                    <?php if ($order->main_image): ?>
+                        <img src=  " <?php echo URLROOT ?>/public/img/uploads/designs/<?php echo $order->main_image ?>"  alt="Design Image">
+                    <?php else: ?>
+                        <img src="<?php echo URLROOT; ?>/public/img/designs/default_design.jpg" alt="Default Design">
+                    <?php endif; ?>
                     <div class="order-image-text">
                         <h4><?php echo $order->name ?></h4>
                         <p class="price"><?php echo $order->total_price ?></p>


### PR DESCRIPTION
This pull request introduces a dynamic image handling feature for customer orders in the `v_c_orders.php` view. The change ensures that the displayed image corresponds to the specific order's main image, with a fallback to a default design image when no main image is available.

### Dynamic image handling for orders:

* [`app/views/users/Customer/v_c_orders.php`](diffhunk://#diff-cdaf17df0bde1905ddce49a3c6ca098fa14354a239063b8a035a757076b23715L14-R18): Updated the `<img>` tag to conditionally display the order's `main_image` if available, or a default image (`default_design.jpg`) otherwise. This improves user experience by dynamically showing relevant images for each order.This pull request updates the `v_c_orders.php` view to dynamically display the correct image for each order. It adds a conditional check to show the main image associated with an order if it exists, and falls back to a default image otherwise.

### Changes to order image display logic:
* Updated the `order-image` section to include a conditional PHP block. If `$order->main_image` is set, it displays the corresponding image from the `uploads/designs` directory. Otherwise, it defaults to showing a placeholder image (`default_design.jpg`).…lt design